### PR TITLE
GH-118 upgrade IDE support to 2026.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -93,7 +93,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -141,7 +141,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       - name: Inspect code
         uses: JetBrains/qodana-action@v2025.1
@@ -169,7 +169,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       # FIXME: enabling this causes the job to fail while stuck in "Post Setup Gradle"
       # - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ group = providers.gradleProperty("pluginGroup").get()
 version = providers.gradleProperty("pluginVersion").get()
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
     compilerOptions {
         freeCompilerArgs.add("-opt-in=kotlin.contracts.ExperimentalContracts")
     }
@@ -42,7 +42,7 @@ dependencies {
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
-        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"), useInstaller = false)
 
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,13 +6,12 @@ pluginRepositoryUrl = https://github.com/akefirad/groom
 pluginVersion = 0.4.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 233
-pluginUntilBuild = 252.*
+pluginSinceBuild = 253
+pluginUntilBuild = 253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-# TODO: with 2024.2.5 tests don't work!
-platformVersion = 2023.3.8
+platformVersion = 2025.3.5
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,17 +6,17 @@ pluginRepositoryUrl = https://github.com/akefirad/groom
 pluginVersion = 0.4.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 253
-pluginUntilBuild = 253.*
+pluginSinceBuild = 261
+pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2025.3.5
+platformVersion = 2026.1.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins =
-platformBundledPlugins = org.intellij.groovy
+platformBundledPlugins = com.intellij.java, org.intellij.groovy
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.12

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.6.0"
+intelliJPlatform = "2.11.0"
 kotlin = "2.2.0"
 kover = "0.9.1"
 qodana = "2025.1.1"
@@ -16,7 +16,7 @@ dependency-licenses = "2.9"
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 groovy = { group = "org.apache.groovy", name = "groovy-test", version = "4.0.27" }
-mockito = { group = "org.mockito", name = "mockito-core", version = "4.11.0" }
+mockito = { group = "org.mockito", name = "mockito-core", version = "5.18.0" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/src/test/groovy/com/akefirad/groom/spock/AssertInlayHintsProviderTest.groovy
+++ b/src/test/groovy/com/akefirad/groom/spock/AssertInlayHintsProviderTest.groovy
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.hints.declarative.InlayProviderPassInfo
 import com.intellij.codeInsight.hints.declarative.impl.DeclarativeInlayHintsPass
 import com.intellij.codeInsight.hints.declarative.impl.inlayRenderer.DeclarativeInlayRenderer
 import com.intellij.codeInsight.hints.declarative.impl.views.TextInlayPresentationEntry
+import com.intellij.codeInsight.multiverse.CodeInsightContexts
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase
@@ -454,6 +455,7 @@ class AssertInlayHintsProviderTest extends LightPlatformCodeInsightFixture4TestC
         def pass = ApplicationManager.application.executeOnPooledThread(
             { new DeclarativeInlayHintsPass(file, editor, [providerInfo], false, false) } as Callable<DeclarativeInlayHintsPass>
         ).get()
+        pass.context = CodeInsightContexts.defaultContext()
         applyPassAndCheckResult(pass, sourceText, expectedText)
     }
 

--- a/src/test/groovy/com/akefirad/groom/spock/AssertInlayHintsProviderTest.groovy
+++ b/src/test/groovy/com/akefirad/groom/spock/AssertInlayHintsProviderTest.groovy
@@ -4,14 +4,17 @@ import com.intellij.codeInsight.hints.InlayDumpUtil
 import com.intellij.codeInsight.hints.declarative.InlayHintsProvider
 import com.intellij.codeInsight.hints.declarative.InlayProviderPassInfo
 import com.intellij.codeInsight.hints.declarative.impl.DeclarativeInlayHintsPass
-import com.intellij.codeInsight.hints.declarative.impl.DeclarativeInlayRenderer
-import com.intellij.codeInsight.hints.declarative.impl.TextInlayPresentationEntry
+import com.intellij.codeInsight.hints.declarative.impl.inlayRenderer.DeclarativeInlayRenderer
+import com.intellij.codeInsight.hints.declarative.impl.views.TextInlayPresentationEntry
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase
 import com.intellij.testFramework.utils.inlays.InlayHintsProviderTestCase
 import org.intellij.lang.annotations.Language
 import org.jetbrains.plugins.groovy.lang.psi.GroovyPsiElementFactory
 import org.junit.Test
+
+import java.util.concurrent.Callable
 
 import static com.akefirad.groom.test.spock.util.SpockSpecification.CODE as SpecificationClass
 
@@ -443,12 +446,14 @@ class AssertInlayHintsProviderTest extends LightPlatformCodeInsightFixture4TestC
         if (verifyHintsPresence) {
             InlayHintsProviderTestCase.Companion.verifyHintsPresence(expectedText)
         }
-        def sourceText = InlayDumpUtil.INSTANCE.removeHints(expectedText)
+        def sourceText = InlayDumpUtil.INSTANCE.removeInlays(expectedText)
         myFixture.configureByText(fileName, sourceText)
         def file = myFixture.file
         def editor = myFixture.editor
         def providerInfo = new InlayProviderPassInfo(provider, "provider.id", enabledOptions)
-        def pass = new DeclarativeInlayHintsPass(file, editor, [providerInfo], false, false)
+        def pass = ApplicationManager.application.executeOnPooledThread(
+            { new DeclarativeInlayHintsPass(file, editor, [providerInfo], false, false) } as Callable<DeclarativeInlayHintsPass>
+        ).get()
         applyPassAndCheckResult(pass, sourceText, expectedText)
     }
 
@@ -459,12 +464,11 @@ class AssertInlayHintsProviderTest extends LightPlatformCodeInsightFixture4TestC
     ) {
         pass.doCollectInformation(new EmptyProgressIndicator())
         pass.applyInformationToEditor()
-        def file = myFixture.file
-        def doc = myFixture.getDocument(file)
         def editor = myFixture.editor
-        def dump = InlayDumpUtil.INSTANCE.dumpHintsInternal(
+        def dump = InlayDumpUtil.INSTANCE.dumpInlays(
             previewText,
-            null,
+            editor,
+            { inlay -> true },
             { r, _ ->
                 (r as DeclarativeInlayRenderer).presentationList
                     .entries
@@ -472,10 +476,9 @@ class AssertInlayHintsProviderTest extends LightPlatformCodeInsightFixture4TestC
                     .collect { it.text }
                     .join("|")
             },
-            file,
-            editor,
-            doc,
             0,
+            false,
+            false,
         )
         assertEquals(expectedText.trim(), dump.trim())
     }


### PR DESCRIPTION
## Summary
- Bump IntelliJ Platform to **2026.1.2** (build 261) — closes #118. Verifier reports `Compatible against IU-261.24374.151`.
- Move JVM toolchain & CI Java to **21** (required by the 2026.1 platform).
- Add `com.intellij.java` to `platformBundledPlugins` (the Java module is no longer transitively on the compile classpath in 261).
- Switch the platform dependency to `useInstaller = false` since the 2026.1 installer artifact isn't published to the Maven layout.
- Adapt `AssertInlayHintsProviderTest`:
  - Imports follow the relocated `inlayRenderer` / `views` subpackages.
  - Switch to the new `InlayDumpUtil` API (`removeInlays`, `dumpInlays(text, editor, filter, renderer, …)`).
  - Construct `DeclarativeInlayHintsPass` on a pooled thread (new `assertBackgroundThread` in `TextEditorHighlightingPass`).
  - Set `pass.context = CodeInsightContexts.defaultContext()` (new multiverse context requirement before `applyInformationToEditor`).
- Bump Mockito to **5.18.0** (4.11.0 cannot mock under Java 21) and the IntelliJ Platform Gradle Plugin to **2.11.0** (last 2.x compatible with Gradle 8).

## Test plan
- [x] `./gradlew check` (42 tests pass, JDK 21)
- [x] `./gradlew verifyPlugin` → "Compatible against IU-261.24374.151" (1 pre-existing deprecation warning on `addPresentation`)
- [ ] CI green on this PR