### PR TITLE
GH-0 release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- GH-118 upgrade IDE support to 2026.1 by @akefirad in https://github.com/akefirad/groom/pull/119
+- GH-121 upgrade dependencies by @akefirad in https://github.com/akefirad/groom/pull/122
+
 ## [0.3.0] - 2025-07-12
 
 - GH-72 groovy constructor folding by @akefirad in https://github.com/akefirad/groom/pull/73

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup = com.akefirad.groom
 pluginName = Groom
 pluginRepositoryUrl = https://github.com/akefirad/groom
-pluginVersion = 0.4.0
+pluginVersion = 0.5.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 261


### PR DESCRIPTION
## Summary
Release prep for **v0.5.0** — bumps `pluginVersion` and adds the `[Unreleased]` changelog entry.

When this PR merges to `main`, the Build workflow will create a draft GitHub release `v0.5.0` whose notes are the `[Unreleased]` section below. Publishing that draft release fires the Release workflow, which runs `publishPlugin` to the JetBrains Marketplace and opens a follow-up changelog-update PR.

## Changes
- `gradle.properties`: `pluginVersion` 0.4.0 → 0.5.0
- `CHANGELOG.md`: `[Unreleased]` entry for #119

## Test plan
- [ ] CI green
- [ ] After merge, verify a draft `v0.5.0` GitHub release is created with the changelog body