### PR TITLE
GH-121 upgrade dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,19 +31,19 @@ jobs:
       pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           add-job-summary-as-pr-comment: on-failure
 
@@ -76,7 +76,7 @@ jobs:
           echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*
@@ -87,16 +87,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           add-job-summary-as-pr-comment: on-failure
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Collect tests result
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests
@@ -132,19 +132,19 @@ jobs:
           large-packages: false
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }} # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0 # a full history is required for pull request analysis
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       - name: Inspect code
-        uses: JetBrains/qodana-action@v2025.1
+        uses: JetBrains/qodana-action@v2025.2
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_205267377 }}
           QODANA_ENDPOINT: "https://qodana.cloud"
@@ -163,17 +163,17 @@ jobs:
           large-packages: false
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       # FIXME: enabling this causes the job to fail while stuck in "Post Setup Gradle"
       # - name: Setup Gradle
-      #   uses: gradle/actions/setup-gradle@v4
+      #   uses: gradle/actions/setup-gradle@v5
       #   with:
       #     add-job-summary-as-pr-comment: on-failure
 
@@ -188,7 +188,7 @@ jobs:
 
       - name: Collect plugin verification result
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
@@ -202,7 +202,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Remove old release drafts
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,18 +17,18 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Export properties
         id: properties

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -32,16 +32,16 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Run IDE
         run: ${{ matrix.runIde }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,18 +4,18 @@ junit = "4.13.2"
 opentest4j = "1.3.0"
 
 # plugins
-changelog = "2.2.1"
+changelog = "2.4.0"
 intelliJPlatform = "2.11.0"
-kotlin = "2.2.0"
+kotlin = "2.2.21"
 kover = "0.9.1"
-qodana = "2025.1.1"
+qodana = "2025.2.1"
 dependency-versions = "0.52.0"
 dependency-licenses = "2.9"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
-groovy = { group = "org.apache.groovy", name = "groovy-test", version = "4.0.27" }
+groovy = { group = "org.apache.groovy", name = "groovy-test", version = "5.0.2" }
 mockito = { group = "org.mockito", name = "mockito-core", version = "5.18.0" }
 
 [plugins]


### PR DESCRIPTION
## Summary
Bundles the open Dependabot upgrades into a single PR — closes #121, supersedes #97, #98, #100, #101, #104, #110, #113, #115, #116.

Skips #114 (`org.jetbrains.intellij.platform 2.6.0 → 2.10.2`) because #119 already moved it to `2.11.0` — the highest 2.x that still supports Gradle 8 (2.12+ requires Gradle 9).

## Bumps

### Libraries / plugins (`gradle/libs.versions.toml`)
- `org.apache.groovy:groovy-test` 4.0.27 → **5.0.2** (#113)
- `org.jetbrains.kotlin.jvm` 2.2.0 → **2.2.21** (#115)
- `org.jetbrains.changelog` 2.2.1 → **2.4.0** (#97)
- `org.jetbrains.qodana` 2025.1.1 → **2025.2.1** (#101)

### GitHub Actions
- `actions/checkout` v4 → **v5** (#98)
- `actions/setup-java` v4 → **v5** (#104)
- `actions/upload-artifact` v4 → **v5** (#116)
- `gradle/actions` v4 → **v5** (#110)
- `JetBrains/qodana-action` v2025.1 → **v2025.2** (#100)

`actions/cache@v4` is left as-is — no Dependabot PR for it.

## Test plan
- [x] `./gradlew check` (42 tests pass, JDK 21)
- [x] `./gradlew verifyPlugin` → "Compatible against IU-261.24374.151"
- [ ] CI green on this PR

## Follow-up
Once this merges, release-prep PR #120 will need a rebase. I'll add a changelog entry for this PR there.