### PR TITLE
GH-0 support IDEA 2026.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion = 0.5.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 261
-pluginUntilBuild = 261.*
+pluginUntilBuild = 262.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
## What
Raises `pluginUntilBuild` from `261.*` to `262.*` so the plugin can be installed on IntelliJ IDEA 2026.2.

## Why
On IDEA 2026.2 (build 262), the marketplace build of Groom 0.5.0 is rejected with *"Incompatible: requires IDE build 261.\* or earlier"*.

## Verification
- JetBrains Plugin Verifier against IU-262.8665.258: **Compatible** — no breaking API usages, one pre-existing deprecation warning (`InlayTreeSink.addPresentation` in `AssertInlayHintsCollector`).
- `./gradlew buildPlugin test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)